### PR TITLE
Fix dices with v49

### DIFF
--- a/Dice/DieBehaviour.cs
+++ b/Dice/DieBehaviour.cs
@@ -93,7 +93,7 @@ namespace MysteryDice.Dice
 
             yield return new WaitForSeconds(3f);
 
-            Landmine.SpawnExplosion(gameObject.transform.position, true, 0, 0);
+            Misc.SpawnExplosion(gameObject.transform.position, true, 0, 0);
             DestroyObject();
 
             if (GameNetworkManager.Instance.localPlayerController.playerClientId == userID)

--- a/Effects/MovingLandmines.cs
+++ b/Effects/MovingLandmines.cs
@@ -79,7 +79,7 @@ namespace MysteryDice.Effects
 
                 if (endDistance < DistanceTolerance)
                 {
-                    Landmine.SpawnExplosion(transform.position, true, 0, 0);
+                    Misc.SpawnExplosion(transform.position, true, 0, 0);
                     Destroy(this.gameObject);
                 }
             }

--- a/Effects/Pathfinder.cs
+++ b/Effects/Pathfinder.cs
@@ -137,7 +137,7 @@ namespace MysteryDice.Effects
 
                 if (endDistance < DistanceTolerance)
                 {
-                    Landmine.SpawnExplosion(transform.position, true, 0, 0);
+                    Misc.SpawnExplosion(transform.position, true, 0, 0);
                     Destroy(this.gameObject);
                 }
             }

--- a/Effects/Purge.cs
+++ b/Effects/Purge.cs
@@ -19,7 +19,7 @@ namespace MysteryDice.Effects
         {
             foreach(var enemy in RoundManager.Instance.SpawnedEnemies)
             {
-                Landmine.SpawnExplosion(enemy.transform.position, true, 2, 5);
+                Misc.SpawnExplosion(enemy.transform.position, true, 2, 5);
                 enemy.KillEnemy(true);
             }
         }

--- a/Misc.cs
+++ b/Misc.cs
@@ -1,10 +1,12 @@
 ﻿using GameNetcodeStuff;
+using HarmonyLib;
 using LethalLib.Modules;
 using MysteryDice.Patches;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
@@ -16,6 +18,8 @@ namespace MysteryDice
 {
     internal class Misc
     {
+        private static bool hasOldLandimeCode = HasOldLandmineCode();
+
         public static void SpawnEnemy(SpawnableEnemyWithRarity enemy, int amount, bool isInside)
         {
             if (!Networker.Instance.IsHost) return;
@@ -97,6 +101,151 @@ namespace MysteryDice
             gameObject.GetComponentInChildren<NetworkObject>().Spawn(destroyWithScene: true);
             RoundManager.Instance.SpawnedEnemies.Add(gameObject.GetComponent<EnemyAI>());
             return gameObject.GetComponentInChildren<NetworkObject>();
+        }
+
+        private static bool HasOldLandmineCode()
+        {
+            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            for (int i = 0; i < assemblies.Length; i++)
+            {
+                Assembly assembly = assemblies[i];
+
+                if (assembly.GetName().Name != "Assembly-CSharp")
+                {
+                    continue;
+                }
+
+                Type landmine = assembly.GetType("Landmine");
+
+                if (landmine == null)
+                {
+                    MysteryDice.CustomLogger.LogMessage($"[HasOldLandmineCode] Landmine not found");
+                    return false;
+                }
+
+                MethodInfo[] methods = landmine.GetMethods();
+
+                for (int j = 0; j < methods.Length; j++)
+                {
+                    MethodInfo method = methods[j];
+                    MysteryDice.CustomLogger.LogMessage($"[HasOldLandmineCode] {method.Name} found");
+
+                    if (method.Name != "SpawnExplosion")
+                    {
+                        MysteryDice.CustomLogger.LogMessage($"[HasOldLandmineCode] {method.Name} found");
+                        continue;
+                    }
+
+                    ParameterInfo[] parameters = method.GetParameters();
+
+                    if (parameters.Length == 4)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public static void SpawnExplosion(Vector3 explosionPosition, bool spawnExplosionEffect = false, float killRange = 1f, float damageRange = 1f, int nonLethalDamage = 50, float physicsForce = 0f, GameObject overridePrefab = null)
+        {
+            if (hasOldLandimeCode)
+            {
+                SpawnExplosion(explosionPosition, spawnExplosionEffect, killRange, damageRange);
+            }
+            else
+            {
+                // Example: Landmine.SpawnExplosion(explosionPosition, spawnExplosionEffect, killRange, damageRange, nonLethalDamage, physicsForce, overridePrefab);
+            }
+        }
+
+        public static void SpawnExplosion(Vector3 explosionPosition, bool spawnExplosionEffect = false, float killRange = 1f, float damageRange = 1f)
+        {
+            Debug.Log("Spawning explosion at pos: {explosionPosition}");
+            if (spawnExplosionEffect)
+            {
+                UnityEngine.Object.Instantiate(StartOfRound.Instance.explosionPrefab, explosionPosition, Quaternion.Euler(-90f, 0f, 0f), RoundManager.Instance.mapPropsContainer.transform).SetActive(value: true);
+            }
+
+            float num = Vector3.Distance(GameNetworkManager.Instance.localPlayerController.transform.position, explosionPosition);
+            if (num < 14f)
+            {
+                HUDManager.Instance.ShakeCamera(ScreenShakeType.Big);
+            }
+            else if (num < 25f)
+            {
+                HUDManager.Instance.ShakeCamera(ScreenShakeType.Small);
+            }
+
+            Collider[] array = Physics.OverlapSphere(explosionPosition, 6f, 2621448, QueryTriggerInteraction.Collide);
+            PlayerControllerB playerControllerB = null;
+            for (int i = 0; i < array.Length; i++)
+            {
+                float num2 = Vector3.Distance(explosionPosition, array[i].transform.position);
+                if (num2 > 4f && Physics.Linecast(explosionPosition, array[i].transform.position + Vector3.up * 0.3f, 256, QueryTriggerInteraction.Ignore))
+                {
+                    continue;
+                }
+
+                if (array[i].gameObject.layer == 3)
+                {
+                    playerControllerB = array[i].gameObject.GetComponent<PlayerControllerB>();
+                    if (playerControllerB != null && playerControllerB.IsOwner)
+                    {
+                        if (num2 < killRange)
+                        {
+                            Vector3 bodyVelocity = (playerControllerB.gameplayCamera.transform.position - explosionPosition) * 80f / Vector3.Distance(playerControllerB.gameplayCamera.transform.position, explosionPosition);
+                            playerControllerB.KillPlayer(bodyVelocity, spawnBody: true, CauseOfDeath.Blast);
+                        }
+                        else if (num2 < damageRange)
+                        {
+                            playerControllerB.DamagePlayer(50);
+                        }
+                    }
+                }
+                else if (array[i].gameObject.layer == 21)
+                {
+                    Landmine componentInChildren = array[i].gameObject.GetComponentInChildren<Landmine>();
+                    if (componentInChildren != null && !componentInChildren.hasExploded && num2 < 6f)
+                    {
+                        Debug.Log("Setting off other mine");
+                        componentInChildren.StartCoroutine(TriggerOtherMineDelayed(componentInChildren));
+                    }
+                }
+                else if (array[i].gameObject.layer == 19)
+                {
+                    EnemyAICollisionDetect componentInChildren2 = array[i].gameObject.GetComponentInChildren<EnemyAICollisionDetect>();
+                    if (componentInChildren2 != null && componentInChildren2.mainScript.IsOwner && num2 < 4.5f)
+                    {
+                        componentInChildren2.mainScript.HitEnemyOnLocalClient(6);
+                    }
+                }
+            }
+
+            int num3 = ~LayerMask.GetMask("Room");
+            num3 = ~LayerMask.GetMask("Colliders");
+            array = Physics.OverlapSphere(explosionPosition, 10f, num3);
+            for (int j = 0; j < array.Length; j++)
+            {
+                Rigidbody component = array[j].GetComponent<Rigidbody>();
+                if (component != null)
+                {
+                    component.AddExplosionForce(70f, explosionPosition, 10f);
+                }
+            }
+        }
+
+        private static IEnumerator TriggerOtherMineDelayed(Landmine mine)
+        {
+            if (!mine.hasExploded)
+            {
+                mine.mineAudio.pitch = UnityEngine.Random.Range(0.75f, 1.07f);
+                mine.hasExploded = true;
+                yield return new WaitForSeconds(0.2f);
+                mine.SetOffMineAnimation();
+            }
         }
     }
 }

--- a/Networker.cs
+++ b/Networker.cs
@@ -174,7 +174,7 @@ namespace MysteryDice
         IEnumerator SpawnExplosionAfterSFX(Vector3 position)
         {
             yield return new WaitForSeconds(0.5f);
-            Landmine.SpawnExplosion(position, true, 1, 5);
+            Misc.SpawnExplosion(position, true, 1, 5);
         }
         #endregion
 
@@ -510,7 +510,7 @@ namespace MysteryDice
         [ClientRpc]
         public void DetonateAtPosClientRPC(Vector3 position)
         {
-            Landmine.SpawnExplosion(position, true, 1, 5);
+            Misc.SpawnExplosion(position, true, 1, 5);
         }
         #endregion
 


### PR DESCRIPTION
This fixes all dices in the version 49 by copying the original Landmine code. Please make sure to run the actual Landmine method of the v50 assembly. I have not tried the v50 and won't for now, so I haven't included it there.
But for v49 it works completely fine